### PR TITLE
#42 Updated Prisma Schema for DonatedItem

### DIFF
--- a/server/prisma/migrations/20241008053147_update_donateditem_relations/migration.sql
+++ b/server/prisma/migrations/20241008053147_update_donateditem_relations/migration.sql
@@ -1,0 +1,20 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `donorEmail` on the `DonatedItem` table. All the data in the column will be lost.
+  - You are about to drop the column `program` on the `DonatedItem` table. All the data in the column will be lost.
+  - Added the required column `donorId` to the `DonatedItem` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `programId` to the `DonatedItem` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "DonatedItem" DROP COLUMN "donorEmail",
+DROP COLUMN "program",
+ADD COLUMN     "donorId" INTEGER NOT NULL,
+ADD COLUMN     "programId" INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "DonatedItem" ADD CONSTRAINT "DonatedItem_donorId_fkey" FOREIGN KEY ("donorId") REFERENCES "Donor"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DonatedItem" ADD CONSTRAINT "DonatedItem_programId_fkey" FOREIGN KEY ("programId") REFERENCES "Program"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -25,16 +25,19 @@ model Donor {
   city         String? @db.VarChar(15)
   zipcode      String  @db.VarChar(20)
   emailOptIn   Boolean
+  donatedItems DonatedItem[] // Add reverse relation to DonatedItem
 }
 
 model DonatedItem {
   id            Int                 @id @default(autoincrement())
   itemType      String              @db.VarChar(50) // Define as VARCHAR(50)
   currentStatus String              @db.VarChar(20) // Define as VARCHAR(20)
-  donorEmail    String              @db.VarChar(100) // Define as VARCHAR(100)
-  program       String              @db.VarChar(50) // Define as VARCHAR(50)
   dateDonated   DateTime
   lastUpdated   DateTime            @updatedAt
+  donorId       Int                 // Foreign key for Donor
+  programId     Int                 // Foreign key for Program
+  donor         Donor               @relation(fields: [donorId], references: [id])
+  program       Program             @relation(fields: [programId], references: [id])
   statuses      DonatedItemStatus[]  // Relation to DonatedItemStatus
 }
 
@@ -53,5 +56,6 @@ model Program {
   name        String   @db.VarChar(100)              
   description String   @db.VarChar(500)              
   startDate   DateTime     @db.Date                          
-  aimAndCause String   @db.VarChar(500)              
+  aimAndCause String   @db.VarChar(500)  
+  donatedItems DonatedItem[] // Add reverse relation to DonatedItem            
 }


### PR DESCRIPTION
**Fixes #42 **

### What was changed?

- Updated the Prisma schema for DonatedItem.

### Why was it changed?

- This change will ensure that each donated item is properly associated with donor and program details, improving data integrity and relationships across the database.

### How was it changed?

- Removed the 'donorEmail' column and replaced it with a foreign key to the 'Donor' table for proper association.

- Removed the `program` column and replaced it with a foreign key to the `Program` table to link each donated item with a program entity.

### Screenshots that show the changes (if applicable):

- **Before:**
  - _Attach screenshot_
- **After:**
  - _Attach screenshot_
