### PR TITLE
#64 Enhance GET /donatedItem to retrive and send images directly to frontend

### DIFF
--- a/client-app/src/Components/DonatedItemDetails.tsx
+++ b/client-app/src/Components/DonatedItemDetails.tsx
@@ -96,7 +96,7 @@ const DonatedItemDetails: React.FC = () => {
                                     {formatDate(status.dateModified)}
                                 </p>
                                 {status.images.map((image: string, index: number) => (
-                                    <img key={index} src={`data:image/jpeg;base64,${image}`} alt={`Status Image ${index}`} style={{ width: '100px', height: '100px', margin: '5px' }} />
+                                    <img key={index} src={`data:image/jpeg;base64,${image}`} className="status-image" />
                                     
                                 ))}
                             </div>

--- a/client-app/src/Components/DonatedItemDetails.tsx
+++ b/client-app/src/Components/DonatedItemDetails.tsx
@@ -89,11 +89,17 @@ const DonatedItemDetails: React.FC = () => {
                             <h2>Donated Item Status</h2>
                         </div>
                         {donatedItem.statuses.map(status => (
-                            <p key={status.id}>
-                                <strong>Status:</strong> {status.statusType} -{' '}
-                                <strong>Modified on:</strong>{' '}
-                                {formatDate(status.dateModified)}
-                            </p>
+                            <div>
+                                <p key={status.id}>
+                                    <strong>Status:</strong> {status.statusType} -{' '}
+                                    <strong>Modified on:</strong>{' '}
+                                    {formatDate(status.dateModified)}
+                                </p>
+                                {status.images.map((image: string, index: number) => (
+                                    <img key={index} src={`data:image/jpeg;base64,${image}`} alt={`Status Image ${index}`} style={{ width: '100px', height: '100px', margin: '5px' }} />
+                                    
+                                ))}
+                            </div>
                         ))}
                     </section>
                 </div>

--- a/client-app/src/Components/DonatedItemsList.tsx
+++ b/client-app/src/Components/DonatedItemsList.tsx
@@ -381,7 +381,7 @@ const DonatedItemsList: React.FC = () => {
                             <td>{index + 1}</td>
                             <td>
                                 <Link
-                                    to={`/item/${item.id}`}
+                                    to={`/donations/${item.id}`}
                                     state={{ itemInfo: item }}
                                 >
                                     {item.id}

--- a/client-app/src/css/DonatedItemDetails.css
+++ b/client-app/src/css/DonatedItemDetails.css
@@ -41,6 +41,12 @@
     margin-bottom: 20px;
 }
 
+.donated-item-status-section .status-image {
+    width: 200px; 
+    height: 200px; 
+    margin: 5px; 
+}
+
 .left-column .item-details-section {
     background-color: #deeaf4;
 }

--- a/client-app/src/css/DonatedItemDetails.css
+++ b/client-app/src/css/DonatedItemDetails.css
@@ -35,26 +35,26 @@
 
 /* Left Column Styling (70% width) */
 .left-column .item-details-section,
-.left-column .status-logs-section {
+.left-column .donated-item-status-section {
     padding: 15px;
     border-radius: 8px;
     margin-bottom: 20px;
 }
 
 .left-column .item-details-section {
-    background-color: #f7e7b9;
+    background-color: #deeaf4;
 }
 
 .left-column .item-details-section .section-header {
-    background-color: #d9b867;
+    background-color: #7ca3c7;
 }
 
 .left-column .donated-item-status-section {
-    background-color: #badaf6;
+    background-color: #f7e7b9;
 }
 
 .left-column .donated-item-status-section .section-header {
-    background-color: #7ca3c7;
+    background-color: #d6ae47;
 }
 
 /* Right Column Styling (30% width) */

--- a/server/src/modals/DonatedItemStatusModal.ts
+++ b/server/src/modals/DonatedItemStatusModal.ts
@@ -1,8 +1,8 @@
 export interface DonatedItemStatus {
     id: number;
     statusType: string;
-    dateModified: string;
+    dateModified: Date;
     donatedItemId: number;
-    imageUrls: string[];
-    images: string[];
+    imageUrls?: string[];
+    images?: string[];
 }

--- a/server/src/routes/donatedItemRoutes.ts
+++ b/server/src/routes/donatedItemRoutes.ts
@@ -4,12 +4,13 @@ import prisma from '../prismaClient'; // Import Prisma client
 import { donatedItemValidator } from '../validators/donatedItemValidator'; // Import the validator
 import { validateDonor } from '../services/donorService';
 import { validateProgram } from '../services/programService';
-import { validateDonatedItem } from '../services/donatedItemService';
+import { fetchImagesFromCloud, validateDonatedItem } from '../services/donatedItemService';
 import {
     uploadToStorage,
     getFileExtension,
 } from '../services/donatedItemService';
 import { date } from 'joi';
+import {DonatedItemStatus} from '../modals/DonatedItemStatusModal';
 
 const router = Router();
 const upload = multer({ storage: multer.memoryStorage() });
@@ -131,6 +132,14 @@ router.get('/:id', async (req: Request, res: Response) => {
                     error: `Donated item with ID ${donatedItemId} not found`,
                 });
         }
+        
+        // Process each status to fetch and encode its images
+        await Promise.all(donatedItem.statuses.map(async (status: DonatedItemStatus) => {
+            const filenames = status.imageUrls || [];
+            const encodedImages = await fetchImagesFromCloud(filenames);
+            status.images = encodedImages;
+        }));
+        
         res.json(donatedItem);
     } catch (error) {
         if (error instanceof Error) {

--- a/server/src/services/donatedItemService.ts
+++ b/server/src/services/donatedItemService.ts
@@ -27,7 +27,6 @@ const fetchImageFromCloud = async (url: string): Promise<string | null> => {
         const fileName = url_chunks[1];
         const stream = await storage.getObject(containerName, fileName);
         const base64Image = await streamToBase64(stream);
-        console.log(base64Image);
         return base64Image;
     } catch (error) {
         console.error('Failed to fetch or encode image:', error);


### PR DESCRIPTION
**Fixes #64 **

### What was changed?

- Update the donations page to display images based on each status.

### Why was it changed?

- This change was made to simplify the client-side logic by handling all cloud storage communications on the server side. Now, the client receives and displays images directly, eliminating the need for additional processing or API calls to retrieve image data.

### How was it changed?
The GET `/donatedItem` endpoint was modified to include logic for fetching image data directly from cloud storage URLs associated with each donated item's status, converting this data to Base64 strings, and embedding these images in the response payload. This was implemented primarily in the `fetchImagesFromCloud` and `streamToBase64` utility functions.


### Screenshots that show the changes (if applicable):

- **Before:**
 
![Sprint_5_1](https://github.com/user-attachments/assets/4c37bb21-be2d-4788-a7f9-6d35e2420714)

- **After:**
![Sprint_5](https://github.com/user-attachments/assets/44b28e0e-6655-4aba-8b9e-a757809f7312)
