### PR TITLE
Fixing Modal Background

### DIFF
--- a/client-app/src/Components/DonorList.tsx
+++ b/client-app/src/Components/DonorList.tsx
@@ -141,7 +141,7 @@ const DonorList: React.FC = () => {
             <Modal
                 isOpen={modalIsOpen}
                 onRequestClose={() => setModalIsOpen(false)}
-                className = "modal-dialog"
+                className="modal-dialog"
             >
                 <div className="modal-container">
                     <h2 className="modal-header">Details</h2>

--- a/client-app/src/Components/DonorList.tsx
+++ b/client-app/src/Components/DonorList.tsx
@@ -141,6 +141,7 @@ const DonorList: React.FC = () => {
             <Modal
                 isOpen={modalIsOpen}
                 onRequestClose={() => setModalIsOpen(false)}
+                className = "modal-dialog"
             >
                 <div className="modal-container">
                     <h2 className="modal-header">Details</h2>

--- a/client-app/src/Components/DonorList.tsx
+++ b/client-app/src/Components/DonorList.tsx
@@ -141,35 +141,33 @@ const DonorList: React.FC = () => {
             <Modal
                 isOpen={modalIsOpen}
                 onRequestClose={() => setModalIsOpen(false)}
-                className="modal-dialog"
+                className="modal-container"
             >
-                <div className="modal-container">
-                    <h2 className="modal-header">Details</h2>
-                    {donorDetails && (
-                        <div className="modal-content">
-                            <p>Donor ID: {donorDetails.id}</p>
-                            <p>First Name: {donorDetails.firstName}</p>
-                            <p>Last Name: {donorDetails.lastName}</p>
-                            <p>Email: {donorDetails.email}</p>
-                            <p>Contact Number: {donorDetails.contact}</p>
-                            <p>Address Line 1: {donorDetails.addressLine1}</p>
-                            <p>Address Line 2: {donorDetails.addressLine2}</p>
-                            <p>City: {donorDetails.city}</p>
-                            <p>State: {donorDetails.state}</p>
-                            <p>Zipcode: {donorDetails.zipcode}</p>
-                            <p>
-                                Opted in for Emails:{' '}
-                                {donorDetails.emailOptIn ? 'Yes' : 'No'}
-                            </p>
-                        </div>
-                    )}
-                    <button
-                        className="close-button"
-                        onClick={() => setModalIsOpen(false)}
-                    >
-                        Close
-                    </button>
-                </div>
+                <h2 className="modal-header">Details</h2>
+                {donorDetails && (
+                    <div>
+                        <p>Donor ID: {donorDetails.id}</p>
+                        <p>First Name: {donorDetails.firstName}</p>
+                        <p>Last Name: {donorDetails.lastName}</p>
+                        <p>Email: {donorDetails.email}</p>
+                        <p>Contact Number: {donorDetails.contact}</p>
+                        <p>Address Line 1: {donorDetails.addressLine1}</p>
+                        <p>Address Line 2: {donorDetails.addressLine2}</p>
+                        <p>City: {donorDetails.city}</p>
+                        <p>State: {donorDetails.state}</p>
+                        <p>Zipcode: {donorDetails.zipcode}</p>
+                        <p>
+                            Opted in for Emails:{' '}
+                            {donorDetails.emailOptIn ? 'Yes' : 'No'}
+                        </p>
+                    </div>
+                )}
+                <button
+                    className="close-button"
+                    onClick={() => setModalIsOpen(false)}
+                >
+                    Close
+                </button>
             </Modal>
 
             <div style={{ position: 'fixed', bottom: '20px', right: '20px' }}>

--- a/client-app/src/css/DonorList.css
+++ b/client-app/src/css/DonorList.css
@@ -28,6 +28,10 @@
     background-color: #fff;
     max-width: 500px;
     margin: 0 auto;
+    text-align: justify;
+    overflow: auto;
+    position: relative;
+    top: 5%;
     border-radius: 8px;
     box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
@@ -39,8 +43,8 @@
     text-align: center;
 }
 
-.modal-content p {
-    margin: 5px 0;
+.modal-content {
+    position: static;
     font-size: 16px;
     color: #333;
 }


### PR DESCRIPTION
**Fixes #104 

### What was changed?

Removed the excess background from the modal when clicking on "View More Details" in /donorlist.

### Why was it changed?

Before, when the user clicked on "View More Details", a large modal popped up. Most of the modal was empty with the exception of a little bit in the middle with the information. The change eliminates the excess space created by the modal and now only shows the intended container.

### How was it changed?

The `<Modal>` tag was altered in `DonorList.tsx` to include a class name. This allows the Modal to be rendered according to the `.modal-container` class, thus removing the need for having a separate `<div>` tag. The className in the `<div>` tag was also removed as this was causing issues with the way the text was displaying in the modal, and without it, there's less need for scrolling. Finally, changes were made to `DonorList.css` to pretty up the modal and restore the original formatting.

### Screenshots that show the changes (if applicable):

*Before*
![image](https://github.com/user-attachments/assets/10e02947-a143-44a0-9ed0-1937e8d04024)

*After*
![image](https://github.com/user-attachments/assets/a88b0512-f7d7-4723-b0be-4d64ccda04b7)
