### PR TITLE
Adding password rules

### DIFF
--- a/client-app/src/Components/Register.js
+++ b/client-app/src/Components/Register.js
@@ -16,9 +16,9 @@ const Register = () => {
         setCredentials({ ...credentials, [name]: value });
 
         // Determine password strength
-        if (value.length < 5) {
+        if (value.length < 12) {
             setPasswordStrength('weak');
-        } else if (value.length >= 5 && value.length <= 8) {
+        } else if (value.length >= 12 && value.length <= 15) {
             setPasswordStrength('medium');
         } else {
             setPasswordStrength('strong');
@@ -35,8 +35,43 @@ const Register = () => {
         }
 
         // Validate password length
-        if (credentials.password.length < 5) {
-            setErrorMessage('Password must be at least 5 characters');
+        if (credentials.password.length < 12) {
+            setErrorMessage('Password must be at least 12 characters');
+            return;
+        }
+
+        //Check Password Rules
+        const missing = [];
+
+        if (!credentials.password.match(/[A-Z]/)) {
+            missing.push('an uppercase');
+        }
+
+        if (!credentials.password.match(/[a-z]/)) {
+            missing.push('a lowercase');
+        }
+
+        if (!credentials.password.match(/[0-9]/)) {
+            missing.push('a number');
+        }
+
+        if (!credentials.password.match(/[^\\w\\s]/)) {
+            missing.push('a special character');
+        }
+
+        if (missing.length !== 0) {
+            if (missing.length === 1) {
+                setErrorMessage('Password must contain ' + missing[0] + '!');
+                return;
+            }
+            const tmp = missing.pop();
+            setErrorMessage(
+                'Password must contain ' +
+                    missing.join(', ') +
+                    ' and ' +
+                    tmp +
+                    '!',
+            );
             return;
         }
 

--- a/client-app/src/Components/Register.js
+++ b/client-app/src/Components/Register.js
@@ -40,7 +40,18 @@ const Register = () => {
             return;
         }
 
-        //Check Password Rules
+        // Check for username or email
+        if (credentials.password.match(credentials.name)) {
+            setErrorMessage('Password must not contain name');
+            return;
+        }
+
+        if (credentials.password.match(credentials.email)) {
+            setErrorMessage('Password must not contain email');
+            return;
+        }
+
+        // Check Password Rules
         const missing = [];
 
         if (!credentials.password.match(/[A-Z]/)) {

--- a/client-app/src/Components/Register.js
+++ b/client-app/src/Components/Register.js
@@ -23,6 +23,60 @@ const Register = () => {
         } else {
             setPasswordStrength('strong');
         }
+
+        // Validate password length
+        if (value.length < 12) {
+            setErrorMessage('Password must be at least 12 characters');
+            return;
+        }
+
+        // Check for username or email
+        if (value.match(credentials.name)) {
+            setErrorMessage('Password must not contain name');
+            return;
+        }
+
+        if (value.match(credentials.email)) {
+            setErrorMessage('Password must not contain email');
+            return;
+        }
+
+        // Check Password Rules
+        const missing = [];
+
+        if (!value.match(/[A-Z]/)) {
+            missing.push('an uppercase');
+        }
+
+        if (!value.match(/[a-z]/)) {
+            missing.push('a lowercase');
+        }
+
+        if (!value.match(/[0-9]/)) {
+            missing.push('a number');
+        }
+
+        if (!value.match(/[$&+,:;=?@#|'<>.^*()%!-]/)) {
+            missing.push('a special character');
+        }
+
+        if (missing.length !== 0) {
+            if (missing.length === 1) {
+                setErrorMessage('Password must contain ' + missing[0] + '!');
+                return;
+            }
+            const tmp = missing.pop();
+            setErrorMessage(
+                'Password must contain ' +
+                    missing.join(', ') +
+                    ' and ' +
+                    tmp +
+                    '!',
+            );
+            return;
+        } else {
+            setErrorMessage('');
+        }
     };
 
     const handleSubmit = async e => {
@@ -66,7 +120,7 @@ const Register = () => {
             missing.push('a number');
         }
 
-        if (!credentials.password.match(/[^\\w\\s]/)) {
+        if (!credentials.password.match(/[$&+,:;=?@#|'<>.^*()%!-]/)) {
             missing.push('a special character');
         }
 

--- a/client-app/src/Components/ResetPasswordPage.js
+++ b/client-app/src/Components/ResetPasswordPage.js
@@ -16,8 +16,49 @@ const ResetPasswordPage = () => {
     const handleSubmit = async e => {
         e.preventDefault();
         try {
-            if (password !== confirmPassword) {
+            if (credentials.password !== credentials.confirm_password) {
                 setError('Passwords do not match');
+                return;
+            }
+
+            // Validate password length
+            if (credentials.password.length < 12) {
+                setError('Password must be at least 12 characters');
+                return;
+            }
+
+            //Check Password Rules
+            const missing = [];
+
+            if (!credentials.password.match(/[A-Z]/)) {
+                missing.push('an uppercase');
+            }
+
+            if (!credentials.password.match(/[a-z]/)) {
+                missing.push('a lowercase');
+            }
+
+            if (!credentials.password.match(/[0-9]/)) {
+                missing.push('a number');
+            }
+
+            if (!credentials.password.match(/[^\\w\\s]/)) {
+                missing.push('a special character');
+            }
+
+            if (missing.length !== 0) {
+                if (missing.length === 1) {
+                    setError('Password must contain ' + missing[0] + '!');
+                    return;
+                }
+                const tmp = missing.pop();
+                setError(
+                    'Password must contain ' +
+                        missing.join(', ') +
+                        ' and ' +
+                        tmp +
+                        '!',
+                );
                 return;
             }
 

--- a/client-app/src/Components/ResetPasswordPage.js
+++ b/client-app/src/Components/ResetPasswordPage.js
@@ -16,33 +16,39 @@ const ResetPasswordPage = () => {
     const handleSubmit = async e => {
         e.preventDefault();
         try {
-            if (credentials.password !== credentials.confirm_password) {
+            if (password !== confirmPassword) {
                 setError('Passwords do not match');
                 return;
             }
 
             // Validate password length
-            if (credentials.password.length < 12) {
+            if (password.length < 12) {
                 setError('Password must be at least 12 characters');
                 return;
             }
 
-            //Check Password Rules
+            // Check for email
+            if (password.match(email)) {
+                setError('Password must not contain email');
+                return;
+            }
+
+            // Check Password Rules
             const missing = [];
 
-            if (!credentials.password.match(/[A-Z]/)) {
+            if (!password.match(/[A-Z]/)) {
                 missing.push('an uppercase');
             }
 
-            if (!credentials.password.match(/[a-z]/)) {
+            if (!password.match(/[a-z]/)) {
                 missing.push('a lowercase');
             }
 
-            if (!credentials.password.match(/[0-9]/)) {
+            if (!password.match(/[0-9]/)) {
                 missing.push('a number');
             }
 
-            if (!credentials.password.match(/[^\\w\\s]/)) {
+            if (!password.match(/[^\\w\\s]/)) {
                 missing.push('a special character');
             }
 


### PR DESCRIPTION
**Fixes #114**

### What was changed?

The following password rules were added to the registration page and the reset password page:

- Minimum 12 characters in length (up from 5)
- At least one uppercase letter (A-Z)
- At least one lowercase letter (a-z)
- At least one numeric digit (0-9)
- At least one special character (e.g., @, #, $, %)
- Must not contain the user's name or email address (name only on Registration)

In addition, custom error messages were added to explain to the user if any of these rules are violated and it will not allow a user to continue unless the user amends the password.

### Why was it changed?

 Before, the only password security consideration was that passwords could not be less than 5 characters. This opened the door for some very weak passwords, and since user accounts have access to see modify programs, donors, and items, this was a potential way for an adversary to significantly disrupt the day to day operations, or potentially dox donors. Now, minimum password requirements are much stronger, patching this potential oversight and forcing users to create stronger passwords. 

### How was it changed?

A series of checks were added to `Register.js` and `ResetPasswordPage.js`. A series of RegExp are used to verify if certain characters exist within the password, and it verifies if a user puts their name or email anywhere in the password.  If these patterns are discovered, an error message pops up. If there are multiple missing characters, an error message is constructed based on whatever's missing and is assembled using the list of characters missing. 
