### PR TITLE
Adding auto-creating donor login

### DIFF
--- a/client-app/src/Components/DonorForm.tsx
+++ b/client-app/src/Components/DonorForm.tsx
@@ -98,20 +98,28 @@ const DonorForm: React.FC = () => {
                     formData,
                 );
                 if (response.status === 201) {
-                    setSuccessMessage('Donor added successfully!');
-                    setFormData({
-                        firstName: '',
-                        lastName: '',
-                        contact: '',
-                        email: '',
-                        addressLine1: '',
-                        addressLine2: '',
-                        state: '',
-                        city: '',
-                        zipcode: '',
-                        emailOptIn: false,
-                    });
-                    navigate('/donorlist');
+                    const login_response = await axios.post(
+                        `${process.env.REACT_APP_BACKEND_API_BASE_URL}donor/register`,
+                        { name: formData.firstName, email: formData.email },
+                    );
+                    if (login_response.status === 201) {
+                        setSuccessMessage('Donor added successfully!');
+                        setFormData({
+                            firstName: '',
+                            lastName: '',
+                            contact: '',
+                            email: '',
+                            addressLine1: '',
+                            addressLine2: '',
+                            state: '',
+                            city: '',
+                            zipcode: '',
+                            emailOptIn: false,
+                        });
+                        navigate('/donorlist');
+                    } else {
+                        setErrorMessage('Donor could not be registered');
+                    }
                 } else {
                     setErrorMessage('Donor not added');
                 }

--- a/server/prisma/migrations/20250303063307_add_role_col_optional/migration.sql
+++ b/server/prisma/migrations/20250303063307_add_role_col_optional/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'DONOR');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "role" "Role";

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -60,10 +60,16 @@ model Program {
   donatedItems DonatedItem[] // Add reverse relation to DonatedItem            
 }
 
+enum Role {
+  ADMIN
+  DONOR
+}
+
 model User {
   id       String @id @default(uuid())
   name     String
   email    String @unique
   password String
   createdAt DateTime @default(now())
+  role      Role?
 }


### PR DESCRIPTION
**Fixes #120**

### What was changed?

Whenever a user adds a new Donor, the Donor is automatically generated an account with a randomized password.

### Why was it changed?

In an effort to add Donor accounts, a method was needed to create accounts for them in such a way that could be done simply and automatically. For this, it was decided to add functionality to the Add Donor Form so that whenever a user adds a new Donor, an account is automatically made. 

### How was it changed?

The Frontend, Backend, and Database needed to be changed in order to achieve this. The database required an additional enum column to be added to the `schema.prisma` file, in order to facilitate the additional RBAC requirement in issue #121. For the backend, a `POST` request was added to `DonorRoutes.ts`, specifically along the path `/donor/register`, which allows for easy calling of the register function without invoking the main `/register`. The `name` and `email` are taken in as JSON parameters and on success, it returns a 201 with the `userId` and the auto-generated `password`. For the frontend, a post call was added `DonorForm.tsx` after the form submit pulling the `firstName` and `email` from the form and passing them as `name` and `email` to the backend.  