### PR TITLE
#108 Implement Backend Logic to Limit Donated Item Image Uploads

### DIFF
--- a/client-app/src/Components/NewItemForm.tsx
+++ b/client-app/src/Components/NewItemForm.tsx
@@ -278,14 +278,14 @@ const NewItemForm: React.FC = () => {
                     setSuccessMessage('Item added successfully!');
                     handleRefresh();
                     navigate('/donations');
-                } else {
-                    setErrorMessage('Item not added');
                 }
             } catch (error: any) {
+              
                 setErrorMessage(
-                    error.response?.data?.message || 'Error adding item',
+                    error.response?.data?.error || 'Error adding item',
                 );
             }
+        
         } else {
             setErrorMessage('Form has validation errors');
         }

--- a/server/src/routes/donatedItemRoutes.ts
+++ b/server/src/routes/donatedItemRoutes.ts
@@ -7,6 +7,7 @@ import { validateProgram } from '../services/programService';
 import {
     fetchImagesFromCloud,
     validateDonatedItem,
+    validateIndividualFileSize,
 } from '../services/donatedItemService';
 import {
     uploadToStorage,
@@ -18,15 +19,19 @@ import { sendDonationEmail } from '../services/emailService';
 import { DonatedItem } from '@prisma/client';
 
 const router = Router();
-const upload = multer({ storage: multer.memoryStorage() });
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // Max file size limit: 5MB
+const upload = multer({ storage: multer.memoryStorage(), limits: { files: 5 } });
 
 // POST /donatedItem - Create a new DonatedItem
 router.post(
     '/',
-    [upload.array('imageFiles'), donatedItemValidator],
+    [upload.array('imageFiles', 5), donatedItemValidator], // Allow up to 5 image files
     async (req: Request, res: Response) => {
         try {
             const imageFiles = req.files as Express.Multer.File[];
+             // Call service functions for validation
+            validateIndividualFileSize(imageFiles); 
+
             const donorId = parseInt(req.body.donorId);
             const programId = parseInt(req.body.programId);
             const { dateDonated, ...rest } = req.body;
@@ -97,7 +102,14 @@ router.post(
                 donatedItemStatus: newStatus,
             });
         } catch (error) {
-            console.error('Error creating donated item:', error);
+            // Handle errors for exceeding file size limit
+            if (error instanceof multer.MulterError && error.code === 'LIMIT_FILE_SIZE') {
+                return res.status(400).json({ message: 'Attached files should not exceed 5MB.' });
+            }
+            // Handle generic errors
+            if (error instanceof Error) {
+                return res.status(400).json({ error: error.message });
+            }
             res.status(500).json({ message: 'Error creating donated item' });
         }
     },

--- a/server/src/services/donatedItemService.ts
+++ b/server/src/services/donatedItemService.ts
@@ -9,6 +9,8 @@ const {
 import prisma from '../prismaClient';
 import { Readable } from 'stream';
 
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // Max file size limit: 5MB
+
 export async function uploadToStorage(
     file: Express.Multer.File,
     filename: string,
@@ -19,6 +21,16 @@ export async function uploadToStorage(
     });
     return `${containerName}/${filename}`;
 }
+
+//  Validate each file size (Max 5MB)
+export const validateIndividualFileSize = (imageFiles: Express.Multer.File[]) => {
+    console.log('Validating individual file sizes');
+    for (const file of imageFiles) {
+        if (file.size > MAX_FILE_SIZE) {
+            throw new Error(`File size is too large. Max file size allowed is 5MB.`);
+        }
+    }
+};
 
 export const fetchImagesFromCloud = async (imageUrls: string[]) => {
     const encodedImages = await Promise.all(


### PR DESCRIPTION
**Fixes #108 **

### What was changed?

- Updated validation logic for new donations to enforce a limit of 5 images and a 5MB file size limit per image.

### Why was it changed?

-  Users could upload more than 5 images or files larger than 5MB, leading to potential performance issues and   inconsistent data.
- Added server-side validation to enforce these limits, ensuring a better user experience and preventing resource overuse.

### How was it changed?
- Added validateImageLimit function to enforce a maximum of 5 images.
- Added validateIndividualFileSize function to ensure no file exceeds 5MB.
- Updated the POST /donatedItem route to call these validation functions.
- Moved validation logic to the service layer (donatedItemService.ts) for better maintainability.
- Updated error messages to be clear and user-friendly.

### Screenshots that show the changes (if applicable):

- **Before:**
  - _Attach screenshot_
- **After:**
  - 
<img width="1451" alt="Screenshot 2025-03-03 at 20 13 51" src="https://github.com/user-attachments/assets/22a96183-7b8f-4964-bf43-09de9bfef948" />

