### PR TITLE
# 122 Email notification for password reset on first login

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -72,4 +72,7 @@ model User {
   password String
   createdAt DateTime @default(now())
   role      Role?
+  firstLogin        Boolean  @default(true)
+  resetToken        String?
+  resetTokenExpiry  DateTime?
 }

--- a/server/src/routes/passwordResetRoutes.ts
+++ b/server/src/routes/passwordResetRoutes.ts
@@ -52,34 +52,38 @@ router.post('/reset-password', async (req: Request, res: Response) => {
     const { token, password } = req.body;
 
     if (!token || !password) {
-        return res.status(400).json({ message: 'Token and password are required' });
-      }
+        return res
+            .status(400)
+            .json({ message: 'Token and password are required' });
+    }
 
-      const isJwt = token.split('.').length === 3; // Check if it's a JWT
-    if (isJwt){
+    const isJwt = token.split('.').length === 3; // Check if it's a JWT
+    if (isJwt) {
         // Handle Forgot Password (JWT Token)
-    try {
-        let decoded: JwtPayload;
-        decoded = jwt.verify(token, JWT_SECRET) as JwtPayload; // Decode and verify the token
-        const userId = decoded.userId;
-        const hashedPassword = await bcrypt.hash(password, 10);
+        try {
+            let decoded: JwtPayload;
+            decoded = jwt.verify(token, JWT_SECRET) as JwtPayload; // Decode and verify the token
+            const userId = decoded.userId;
+            const hashedPassword = await bcrypt.hash(password, 10);
 
-        // Store new password in database
-        // const updatedUser = 
-        await prisma.user.update({
-            where: { id: userId },
-            data: { password: hashedPassword }, // The new hashed password
-        });
+            // Store new password in database
+            // const updatedUser =
+            await prisma.user.update({
+                where: { id: userId },
+                data: { password: hashedPassword }, // The new hashed password
+            });
 
             return res.status(200).json({
                 message: 'Password changed successfully',
             });
         } catch (error) {
-             console.log('Login Error. JWT validation failed.');
-             return res.status(401).json({ message: 'Invalid or expired token.' });
-         }
-     } else {
-        try{
+            console.log('Login Error. JWT validation failed.');
+            return res
+                .status(401)
+                .json({ message: 'Invalid or expired token.' });
+        }
+    } else {
+        try {
             const hashedToken = crypto
                 .createHash('sha256')
                 .update(token)
@@ -92,9 +96,10 @@ router.post('/reset-password', async (req: Request, res: Response) => {
                 },
             });
             if (!user) {
-                return res
-                    .status(400)
-                    .json({ message: 'Invalid or expired reset token. Please submit another password reset request.' });
+                return res.status(400).json({
+                    message:
+                        'Invalid or expired reset token. Please submit another password reset request.',
+                });
             }
 
             if (user.firstLogin && user.role === 'DONOR') {

--- a/server/src/routes/programRoutes.ts
+++ b/server/src/routes/programRoutes.ts
@@ -3,6 +3,8 @@ import prisma from '../prismaClient'; // Import Prisma client
 import { body, validationResult } from 'express-validator';
 import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
+import { sendPasswordReset } from '../services/emailService';
 
 const router = Router();
 const JWT_SECRET = process.env.JWT_SECRET; // Use secret from .env
@@ -91,6 +93,35 @@ router.post(
             const isMatch = await bcrypt.compare(password, user.password);
             if (!isMatch) {
                 return res.status(401).json({ message: 'Invalid password.' });
+            }
+
+            // First Login: Force Password Reset
+            if (user.firstLogin && user.role === 'DONOR') {
+                // Generate a secure token
+                const rawToken = crypto.randomBytes(32).toString('hex');
+                const hashedToken = crypto
+                    .createHash('sha256')
+                    .update(rawToken)
+                    .digest('hex');
+                const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 60 minutes
+
+                // Save token and expiry in the user record
+                await prisma.user.update({
+                    where: { id: user.id },
+                    data: {
+                        resetToken: hashedToken,
+                        resetTokenExpiry: expiresAt,
+                    },
+                });
+
+                // Send reset email with the raw token
+                await sendPasswordReset(user.email, rawToken);
+
+                return res.status(403).json({
+                    message:
+                        'Please reset your password using the link sent to your email.',
+                    requireReset: true,
+                });
             }
 
             // Generate JWT token and it expires in 1hr.

--- a/server/src/services/emailService.ts
+++ b/server/src/services/emailService.ts
@@ -57,15 +57,17 @@ export const sendPasswordReset = async (
     recipientEmail: string,
     resetToken: string,
 ) => {
+    const resetUrl = `${process.env.FRONTEND_URL}reset-password?token=${resetToken}`;
     const mailOptions = {
         from: `Donation Team <${process.env.SMTP_USER}>`,
         to: recipientEmail,
         subject: 'Material Donor Mutual Assist Password Reset',
         html: `
             <h2>Hello there!</h2>
-            <p>We have recently received a request to change the password of the account linked to this email.</p>
-            <p>If this was you, please follow this link here ${process.env.FRONTEND_URL}reset-password?token=${token} to reset your password.</p>
-            <p>If this was not you, please feel free to disregard this email.</p>
+            <<p>We received a request to reset your password. If this was you, click the link below:</p>
+            <p><a href="${resetUrl}" style="color: blue; text-decoration: underline;">${resetUrl}</a></p>
+            <p><strong>This link will expire in 60 minutes.</strong></p>
+            <p>If this wasn’t you, please ignore this email.</p>
             <p>Best regards,</p>
             <p><strong>Donation Team</strong></p>
         `,

--- a/server/src/services/emailService.ts
+++ b/server/src/services/emailService.ts
@@ -55,7 +55,7 @@ export const sendWelcomeEmail = async (
 
 export const sendPasswordReset = async (
     recipientEmail: string,
-    token: string,
+    resetToken: string,
 ) => {
     const mailOptions = {
         from: `Donation Team <${process.env.SMTP_USER}>`,
@@ -64,8 +64,7 @@ export const sendPasswordReset = async (
         html: `
             <h2>Hello there!</h2>
             <p>We have recently received a request to change the password of the account linked to this email.</p>
-            <p>If this was you, please follow this link here ${process.env.FRONTEND_URL}reset-password?token=${token} to reset your password.
-            This link will expire in 1 hour.</p>
+            <p>If this was you, please follow this link here ${process.env.FRONTEND_URL}reset-password?token=${token} to reset your password.</p>
             <p>If this was not you, please feel free to disregard this email.</p>
             <p>Best regards,</p>
             <p><strong>Donation Team</strong></p>
@@ -73,7 +72,8 @@ export const sendPasswordReset = async (
     };
 
     try {
-        const result = await transporter.sendMail(mailOptions);
+        await transporter.sendMail(mailOptions);
+        console.log(`Password reset email sent to ${recipientEmail}`);
         transporter.close();
     } catch (error) {
         console.log('Error sending email:', error);


### PR DESCRIPTION
**Fixes #issue_122**

### What was changed?

When a donor is added by an admin, a random temporary password is generated and saved. Upon first login using those credentials, the donor is prompted to reset their password before accessing their account. They are also sent an email with a secure password reset link. Until the password is updated, access to the account is restricted.

### Why was it changed?

To enhance the security of donor accounts, donors are added by an admin and are not aware of their login credentials.
Therefore, a secure password reset link is sent to their registered email, allowing them to set their own password before accessing their account.

### How was it changed?

The User model in the Prisma schema has been updated to include the fields: firstLogin, resetToken, and resetTokenExpiry to support secure first-time login for donors.
In both programRoutes and donorRoutes, the system checks whether a donor is logging in for the first time. If so, a secure token is generated and stored along with an expiry time of 1 hour.
The emailService then sends a password reset email containing the token to the donor, prompting them to reset their password before gaining access to the system.

### Screenshots that show the changes (if applicable):

_Include screenshots or visual representations of the changes, especially for user interface updates._

- **Before:**
  NA
- **After:**
 
![Screenshot 2025-03-31 112751](https://github.com/user-attachments/assets/4b203cf9-686c-466b-9b7b-ef278a88d1cf)


