### PR TITLE
Fixing time zone offset bug

### DIFF
--- a/client-app/src/Components/DonatedItemDetails.tsx
+++ b/client-app/src/Components/DonatedItemDetails.tsx
@@ -29,13 +29,10 @@ const DonatedItemDetails: React.FC = () => {
             try {
                 const API_BASE_URL =
                     process.env.REACT_APP_BACKEND_API_BASE_URL || '';
-                console.log(API_BASE_URL);
-                console.log(id);
                 const response = await axios.get<DonatedItem>(
                     `${API_BASE_URL}donatedItem/${id}`,
                 );
 
-                console.log(response);
                 setDonatedItem(response.data);
             } catch (err) {
                 if (axios.isAxiosError(err)) {
@@ -54,9 +51,12 @@ const DonatedItemDetails: React.FC = () => {
         fetchDonatedItemDetails();
     }, [id]);
 
-    const formatDate = (dateString: string) => {
+    const formatDate = (dateString: string, isUTC: boolean) => {
         const date = new Date(dateString);
-        return isNaN(date.getTime()) ? 'Invalid date' : date.toDateString();
+        if (isNaN(date.getTime())) return 'Invalid date';
+        if (!isUTC)
+            date.setTime(date.getTime() + date.getTimezoneOffset() * 60 * 1000);
+        return date.toDateString();
     };
 
     if (loading) return <div>Loading...</div>;
@@ -89,7 +89,7 @@ const DonatedItemDetails: React.FC = () => {
                                     active={true}
                                     completed={false}
                                 >
-                                    <StepLabel>{`${status.statusType} (${formatDate(status.dateModified)})`}</StepLabel>
+                                    <StepLabel>{`${status.statusType} (${formatDate(status.dateModified, false)})`}</StepLabel>
 
                                     <StepContent>
                                         <div className="image-scroll-container">
@@ -124,11 +124,11 @@ const DonatedItemDetails: React.FC = () => {
                         </p>
                         <p>
                             <strong>Donated On:</strong>{' '}
-                            {formatDate(donatedItem.dateDonated)}
+                            {formatDate(donatedItem.dateDonated, false)}
                         </p>
                         <p>
                             <strong>Last Updated:</strong>{' '}
-                            {formatDate(donatedItem.lastUpdated)}
+                            {formatDate(donatedItem.lastUpdated, true)}
                         </p>
                     </section>
 
@@ -174,7 +174,7 @@ const DonatedItemDetails: React.FC = () => {
                         </p>
                         <p>
                             <strong>Start Date:</strong>{' '}
-                            {formatDate(donatedItem.program?.startDate)}
+                            {formatDate(donatedItem.program?.startDate, false)}
                         </p>
                         <p>
                             <strong>Aim and Cause:</strong>{' '}

--- a/client-app/src/Components/DonatedItemsList.tsx
+++ b/client-app/src/Components/DonatedItemsList.tsx
@@ -296,9 +296,10 @@ const DonatedItemsList: React.FC = () => {
                             <td>{item.itemType}</td>
                             <td>{item.currentStatus}</td>
                             <td>
-                                {new Date(
-                                    item.dateDonated,
-                                ).toLocaleDateString()}
+                                {new Date(item.dateDonated).toLocaleDateString(
+                                    undefined,
+                                    { timeZone: 'UTC' },
+                                )}
                             </td>
                             <td>
                                 <div>
@@ -336,14 +337,18 @@ const DonatedItemsList: React.FC = () => {
                             Date Donated:{' '}
                             {new Date(
                                 selectedItemDetails.dateDonated,
-                            ).toLocaleDateString()}
+                            ).toLocaleDateString(undefined, {
+                                timeZone: 'UTC',
+                            })}
                         </p>
                         {selectedItemDetails.lastUpdated && (
                             <p>
                                 Last Updated:{' '}
                                 {new Date(
                                     selectedItemDetails.lastUpdated,
-                                ).toLocaleDateString()}
+                                ).toLocaleDateString(undefined, {
+                                    timeZone: 'UTC',
+                                })}
                             </p>
                         )}
                         <p>
@@ -370,7 +375,10 @@ const DonatedItemsList: React.FC = () => {
                                                     {status.statusType} -{' '}
                                                     {new Date(
                                                         status.dateModified,
-                                                    ).toLocaleDateString()}
+                                                    ).toLocaleDateString(
+                                                        undefined,
+                                                        { timeZone: 'UTC' },
+                                                    )}
                                                 </li>
                                             ),
                                         )}

--- a/server/src/services/emailService.ts
+++ b/server/src/services/emailService.ts
@@ -103,6 +103,7 @@ export const sendDonationEmail = async (
         year: 'numeric',
         month: 'long',
         day: 'numeric',
+        timeZone: 'UTC',
     });
     const imageSection =
         SASUrls.length > 0


### PR DESCRIPTION
# Date Offset Bug

**Fixes #160**

### What was changed?

Timezones were altered and offset was removed on the `/donations` pages where not appropriate to correct the dates being displayed.

### Why was it changed?

Before, the dates on the `/donations` page were inaccurate, often erroneously attributing donations on the day before they were actually donated. This could cause confusion amongst not only the employees who are setting the donation info, but also the donors themselves who may get confused as to why they are getting status updates a day later. By fixing this, the website now accurately displays dates.

### How was it changed?

For the list of donated items on the donor list, the `DonatedItemsList.tsx` file was altered, specifically the instances of `toLocaleString()` calls to set the option `timeZone` to UTC time, which removes the offset `toLocaleString()` has by default to the correct timezone. For the individual donated items information, the `DonatedItemDetails.tsx` file was modified, specifically the `formatDate()` function and calls to it to add a boolean that when false, removes the offset applied to the date when `toDateString()` is called. 