### PR TITLE
#142 Edited Item Details in Existing Donations

### DIFF
--- a/server/src/routes/donatedItemRoutes.ts
+++ b/server/src/routes/donatedItemRoutes.ts
@@ -198,7 +198,7 @@ router.get('/:id', async (req: Request, res: Response) => {
     }
 });
 
-// PUT /donatedItem/details/:id - Update non-status details of a DonatedItem
+// PUT /donatedItem/details/:id - Update donated item details (excluding status)
 router.put(
     '/details/:id',
     donatedItemValidator,
@@ -206,6 +206,7 @@ router.put(
         try {
             const donorId = parseInt(req.body.donorId);
             const programId = parseInt(req.body.programId);
+
             try {
                 await validateDonor(donorId);
                 await validateProgram(programId);
@@ -215,17 +216,27 @@ router.put(
                 }
             }
 
+            const dateDonatedDateTime = new Date(req.body.dateDonated);
+
             const updatedItem = await prisma.donatedItem.update({
                 where: { id: Number(req.params.id) },
                 data: {
-                    ...req.body,
+                    itemType: req.body.itemType,
+                    dateDonated: dateDonatedDateTime,
                     donorId,
                     programId,
                     lastUpdated: new Date(),
                 },
             });
-            console.log('Donated item updated:', updatedItem);
-            res.json(updatedItem);
+
+            console.log(
+                'Donated item updated (admin-only, no status):',
+                updatedItem,
+            );
+            res.status(200).json({
+                message: 'Item updated successfully',
+                data: updatedItem,
+            });
         } catch (error) {
             console.error('Error updating donated item details:', error);
             res.status(500).json({


### PR DESCRIPTION
**#142**

### What was changed?

Enabled editing of donated item details for admins, including item type, donation date. Also updated the backend to handle and validate these changes properly.

### Why was it changed?

- Admins needed the ability to correct or update item information after a donation has been submitted, which was previously not supported.
- This improves data accuracy and program tracking within the system.

### How was it changed?

- Added a dropdown for currentStatus to the edit form in DonatedItemDetails.tsx.
- Refactored the PUT route in donatedItemRoutes.ts to handle updates for currentStatus and ensure proper validation of dateDonated.

### Screenshots that show the changes (if applicable):

- **Before:**
  - _Attach screenshot_
- **After:**
  -
<img width="1456" alt="#142_1" src="https://github.com/user-attachments/assets/74b3e98b-7675-4da7-8be0-0186ca615830" />
<img width="1460" alt="#142_2" src="https://github.com/user-attachments/assets/970fb9e5-51ee-49ac-868c-d18f55791d48" />

