### PR TITLE
fix: change theme of the donor form to light theme

### DIFF
--- a/client-app/src/Components/DonorForm.tsx
+++ b/client-app/src/Components/DonorForm.tsx
@@ -310,22 +310,7 @@ const DonorForm: React.FC = () => {
                     </div>
                 </div>
 
-                <div className="form-field full-width button-container">
-                    <button
-                        type="submit"
-                        className="submit-button"
-                        disabled={isLoading}
-                    >
-                        Submit
-                    </button>
-                    <button
-                        type="button"
-                        onClick={handleRefresh}
-                        className="refresh-button"
-                        disabled={isLoading}
-                    >
-                        Refresh
-                    </button>
+                <div className="button-container">
                     <button
                         type="button"
                         onClick={handleBack}
@@ -334,6 +319,23 @@ const DonorForm: React.FC = () => {
                     >
                         Back
                     </button>
+                    <div className="button-group-right">
+                        <button
+                            type="button"
+                            onClick={handleRefresh}
+                            className="refresh-button"
+                            disabled={isLoading}
+                        >
+                            Refresh
+                        </button>
+                        <button
+                            type="submit"
+                            className="submit-button"
+                            disabled={isLoading}
+                        >
+                            Submit
+                        </button>
+                    </div>
                 </div>
 
                 {isLoading && <LoadingSpinner />}

--- a/client-app/src/css/DonorForm.css
+++ b/client-app/src/css/DonorForm.css
@@ -65,6 +65,20 @@
     color: #333;
 }
 
+/* Button container styling */
+.donor-form .button-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 30px;
+    width: 100%;
+}
+
+.donor-form .button-group-right {
+    display: flex;
+    gap: 15px;
+}
+
 /* Button styling */
 .donor-form .submit-button {
     padding: 10px 25px;
@@ -77,7 +91,6 @@
     transition:
         background-color 0.3s ease,
         transform 0.2s ease;
-    margin-right: 20px; /* Space between Add Donor and Refresh buttons */
 }
 
 .donor-form .submit-button:hover {
@@ -93,10 +106,12 @@
     border-radius: 6px;
     cursor: pointer;
     font-size: 14px;
+    position: relative;
+    right: 320px;
+    top: 40px;
     transition:
         background-color 0.3s ease,
         transform 0.2s ease;
-    margin-right: 20px;
 }
 
 /* This should be fixed to a point where it is not hardcoded some point in the future*/
@@ -120,7 +135,7 @@
 
 /* Button hover effect */
 .donor-form .refresh-button:hover {
-    background-color: #eaeaea !important;
+    background-color: #ebebeb !important;
     transform: translateY(0) !important;
 }
 


### PR DESCRIPTION
# Pull Request Template

**Fixes #213**

### What was changed?

The **Add Donor Details** form was redesigned to fit the updated light theme.

- Changed background from dark to white.
- Updated layout, spacing, typography, and button styles to match the new design system.
- Added multi-column layout for related fields to improve space and readability.

### Why was it changed?

The previous dark background didn't match the light theme, making the UI inconsistent. This update improves the visual design and user experience.

### How was it changed?

- Form container transitioned to a white card-based design.
- Spacing, typography, and button styles were standardized.

### Screenshots that show the changes (if applicable):

- **Before:**
<img width="2940" height="1526" alt="image" src="https://github.com/user-attachments/assets/c911c391-e07e-4a8c-9cdd-2eda7a4a0476" />
- **After:**
<img width="1244" height="841" alt="Screenshot 2025-10-18 at 2 05 24 PM" src="https://github.com/user-attachments/assets/e1b73690-65c7-4295-bb16-cab734e531b5" />
