### PR TITLE
changes in forgot password page

### DIFF
--- a/client-app/src/Components/ForgotPassword.tsx
+++ b/client-app/src/Components/ForgotPassword.tsx
@@ -1,67 +1,108 @@
 import React, { useState, ChangeEvent, FormEvent } from 'react';
-import emailjs from 'emailjs-com';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
+import '../css/ForgotPassword.css';
 
 const ForgotPassword: React.FC = () => {
     const navigate = useNavigate();
     const [email, setEmail] = useState<string>('');
+    const [error, setError] = useState<string>('');
+    const [success, setSuccess] = useState<string>('');
+    const [isLoading, setIsLoading] = useState<boolean>(false);
 
-    const handleSubmit = async (e: React.FormEvent) => {
+    const validateEmail = (mail: string) =>
+        /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(mail);
+
+    const handleSubmit = async (e: FormEvent) => {
         e.preventDefault();
+        setError('');
+        setSuccess('');
 
+        if (!validateEmail(email)) {
+            setError('Please enter a valid email address.');
+            return;
+        }
+
+        setIsLoading(true);
         try {
             const response = await fetch(
                 `${process.env.REACT_APP_BACKEND_API_BASE_URL}passwordReset/forgotpassword`,
                 {
                     method: 'POST',
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
+                    headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ email }),
                 },
             );
 
-            const data = await response.json();
-            if (!response.ok) {
-                throw new Error(data.message);
-            }
-            console.log('Email sent:', data.message);
-            alert('A password reset link has been sent to your email.');
-        } catch (error) {
-            console.error('Error sending password reset email:', error);
-            const errorMessage =
-                error instanceof Error
-                    ? error.message
-                    : 'An unknown error occurred';
-            if (errorMessage.includes('not found')) {
-                alert('That email is not linked to a registered account.');
-            } else if (errorMessage.includes('sending email')) {
-                alert(
-                    'There was an error sending the reset email. Please try again.',
+            const data = await response.json().catch(() => ({}));
+            if (response.ok) {
+                setSuccess(
+                    'If this email is registered, a reset link has been sent.',
                 );
+                // Optionally redirect after a short delay:
+                // setTimeout(() => navigate('/login'), 2500);
             } else {
-                alert(error);
+                setError(
+                    data.message ||
+                        'Unable to process request. Try again later.',
+                );
             }
+        } catch (err) {
+            setError('Network error. Please try again.');
+        } finally {
+            setIsLoading(false);
         }
     };
 
     const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
         setEmail(e.target.value);
+        setError('');
+        setSuccess('');
     };
 
     return (
-        <div>
-            <h2>Forgot Password</h2>
-            <form onSubmit={handleSubmit}>
-                <input
-                    type="email"
-                    value={email}
-                    onChange={handleChange}
-                    placeholder="Enter your email"
-                    required
-                />
-                <button type="submit">Submit</button>
-            </form>
+        <div className="fp-page">
+            <div className="fp-card">
+                <h2 className="fp-title">Forgot Password</h2>
+
+                {error && <div className="fp-message fp-error">{error}</div>}
+                {success && (
+                    <div className="fp-message fp-success">{success}</div>
+                )}
+
+                <form className="fp-form" onSubmit={handleSubmit} noValidate>
+                    <label htmlFor="fp-email" className="fp-label">
+                        Enter your email address
+                    </label>
+                    <input
+                        id="fp-email"
+                        type="email"
+                        className="fp-input"
+                        value={email}
+                        onChange={handleChange}
+                        placeholder="you@example.com"
+                        required
+                    />
+
+                    <div className="fp-actions">
+                        <button
+                            type="submit"
+                            className="fp-btn"
+                            disabled={isLoading}
+                            aria-busy={isLoading}
+                        >
+                            {isLoading ? 'Sending...' : 'Send reset link'}
+                        </button>
+                        <Link to="/login" className="fp-link">
+                            Back to Login
+                        </Link>
+                    </div>
+                </form>
+
+                <p className="fp-note">
+                    We will send a secure link to reset your password. Check
+                    spam/junk if you don't see it.
+                </p>
+            </div>
         </div>
     );
 };

--- a/client-app/src/css/ForgotPassword.css
+++ b/client-app/src/css/ForgotPassword.css
@@ -1,0 +1,116 @@
+.fp-page {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 72vh;
+    background: #f1f7fb;
+    padding: 24px;
+}
+
+.fp-card {
+    width: 100%;
+    max-width: 480px;
+    background: #ffffff;
+    border-radius: 10px;
+    padding: 28px;
+    box-shadow: 0 6px 20px rgba(16, 24, 40, 0.06);
+    border: 1px solid rgba(16, 24, 40, 0.04);
+}
+
+.fp-title {
+    margin: 0 0 8px;
+    font-size: 20px;
+    color: #0b2545;
+}
+
+.fp-label {
+    display: block;
+    font-size: 13px;
+    color: #475569;
+    margin-top: 12px;
+    margin-bottom: 6px;
+}
+
+.fp-input {
+    width: 100%;
+    padding: 10px 12px;
+    border-radius: 6px;
+    border: 1px solid #e6e9ef;
+    font-size: 14px;
+    outline: none;
+    transition:
+        border-color 0.12s ease,
+        box-shadow 0.12s ease;
+}
+
+.fp-input:focus {
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.06);
+}
+
+.fp-actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 16px;
+}
+
+.fp-btn {
+    background: #2563eb;
+    color: #fff;
+    padding: 10px 14px;
+    border-radius: 8px;
+    border: none;
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.fp-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.fp-link {
+    color: #2563eb;
+    text-decoration: none;
+    font-size: 14px;
+}
+
+.fp-message {
+    padding: 10px 12px;
+    border-radius: 8px;
+    margin-top: 12px;
+    font-size: 14px;
+}
+
+.fp-error {
+    background: #fff5f5;
+    color: #9b1c1c;
+    border: 1px solid rgba(185, 28, 28, 0.06);
+}
+
+.fp-success {
+    background: #ecfdf5;
+    color: #065f46;
+    border: 1px solid rgba(6, 95, 70, 0.06);
+}
+
+.fp-note {
+    margin-top: 12px;
+    font-size: 13px;
+    color: #6b7280;
+}
+
+/* small screens */
+@media (max-width: 520px) {
+    .fp-card {
+        padding: 18px;
+    }
+    .fp-actions {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .fp-link {
+        text-align: center;
+    }
+}


### PR DESCRIPTION
Fixes #305 

### What was changed?
- Replaced the minimal “submit-only” view with a centered card layout and clearer form hierarchy.
- Added client-side email validation, loading state, and success/error messaging.
- Introduced responsive styles and accessible focus/aria patterns.

### Why was it changed?
-The previous screen felt incomplete and off-brand.
- This brings the page in line with current UI (card, spacing, shadows), improves clarity, and sets a consistent baseline before core auth tasks are assigned.

### How was it changed?

- Layout: .fp-page for centered flex container; .fp-card as white panel with radius, border, and shadow.
- Form UX: .fp-label, .fp-input with focus ring; .fp-actions for button + link; responsive stack ≤520px.
- States: Inline email validation (regex), isLoading to disable button + show “Sending…”, conditional .fp-success/.fp-error banners.
- API call: POST ${process.env.REACT_APP_BACKEND_API_BASE_URL}passwordReset/forgotpassword with { email }; friendly success text even when email is unknown to avoid account enumeration.

### Screenshots that show the changes :

- **Before:**
<img width="1304" height="513" alt="image" src="https://github.com/user-attachments/assets/b14fa948-6817-42f7-899d-0c03ef436161" />


- **After:**
<img width="1439" height="814" alt="image" src="https://github.com/user-attachments/assets/c4cb1df8-d09a-46a1-b30e-2bcc28190fbe" />


