### PR TITLE
Independent User Management Tab

### DIFF
--- a/client-app/src/Components/Navbar.tsx
+++ b/client-app/src/Components/Navbar.tsx
@@ -320,34 +320,34 @@ const Navbar: React.FC = () => {
                                             </ul>
                                         </li>
                                         <li
-                                            className="nav-item dropdown"
+                                            className="nav-item"
                                             style={{
                                                 fontSize: '20px',
                                                 paddingLeft: '10px',
                                             }}
                                         >
-                                            <span
-                                                className="nav-link dropdown-toggle"
-                                                id="navbarDropdown"
-                                                role="button"
-                                                data-bs-toggle="dropdown"
-                                                aria-expanded="false"
+                                            <Link
+                                                className="nav-link"
+                                                to="/admin/user-management"
+                                                style={{
+                                                    fontWeight:
+                                                        location.pathname ===
+                                                            '/about' ||
+                                                        location.pathname ===
+                                                            '/'
+                                                            ? 'normal'
+                                                            : 'bold',
+                                                    color:
+                                                        location.pathname ===
+                                                            '/about' ||
+                                                        location.pathname ===
+                                                            '/'
+                                                            ? 'black'
+                                                            : 'inherit',
+                                                }}
                                             >
                                                 Users
-                                            </span>
-                                            <ul
-                                                className="dropdown-menu"
-                                                aria-labelledby="navbarDropdown"
-                                            >
-                                                <li>
-                                                    <Link
-                                                        className="dropdown-item"
-                                                        to="/admin/user-management"
-                                                    >
-                                                        User Management
-                                                    </Link>
-                                                </li>
-                                            </ul>
+                                            </Link>
                                         </li>
                                     </>
                                 )}


### PR DESCRIPTION
# Pull Request

**Fixes #393 **

### What was changed?

- Instead of User Management being under Donors (which makes no sense) it is now its own standalone tab, like About.

### Why was it changed?

- Cleaner look, less buttons, #393 

### How was it changed?

- The About section of the Navbar.tsx was copied and replaced with the User Management link instead.

### Screenshots that show the changes (if applicable):

- **Before:**
<img width="1914" height="498" alt="image" src="https://github.com/user-attachments/assets/567f8580-03dd-41d1-aa51-dd654f3ec484" />

- **After:**
<img width="670" height="76" alt="image" src="https://github.com/user-attachments/assets/b7ea779e-baf5-4dc9-ae97-412efef06dc5" />
