### PR TITLE
fixed(deps)(deps-dev): bump @types/node from 24.10.4 to 25.5.0  in server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -46,7 +46,7 @@
         "@types/jsonwebtoken": "^9.0.8",
         "@types/morgan": "^1.9.9",
         "@types/multer": "^2.0.0",
-        "@types/node": "^24.9.1",
+        "@types/node": "25.5.0",
         "@types/nodemailer": "^7.0.3",
         "@types/supertest": "^6.0.2",
         "jest": "^30.2.0",


### PR DESCRIPTION
Summary
Updates @types/node in /server to the latest available version (25.5.0).
Replaces the previous 25.0.3 bump in PR #370 with the current latest release.

Change is limited to server/package.json.
No runtime code changes; this is a dev dependency update only.

Related
Supersedes [#370](https://github.com/oss-slu/material-derailleur/pull/370).
