### PR TITLE
fix(server): run prisma generate during docker build

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma/
 RUN npm install
+RUN npx prisma generate
 COPY . .
 EXPOSE 5050
 CMD ["npm", "run", "dev:docker"]


### PR DESCRIPTION
The Dockerfile installs dependencies but never generates the Prisma client, so @prisma/client at runtime tries to load .prisma/client/default and fails with MODULE_NOT_FOUND. Adding 'npx prisma generate' after 'npm install' bakes the generated client into the image so the import in src/prismaClient.ts resolves correctly.

Combined with the package.json prisma v6 pin in this branch, verified locally with a clean docker build and run: server reaches database connection step (P1001 against fake host).
