### PR TITLE
Rename onResult to onDecodeResult in DonatedItemsList

### DIFF
--- a/client-app/src/Components/DonatedItemsList.tsx
+++ b/client-app/src/Components/DonatedItemsList.tsx
@@ -72,7 +72,7 @@ const DonatedItemsList: React.FC = () => {
 
     const { ref } = useZxing({
         constraints: { video: { facingMode: 'environment' } },
-        onResult(result: Result) {
+        onDecodeResult(result: Result) {
             setSearchInput(result.getText());
             setScanning(false);
             setError(null);


### PR DESCRIPTION
onResult was renamed to onDecodeResult in the new version of react-zxing

It was not caught in my last pull request likely due to caching of old modules by VSCode