### PR TITLE
client: fix subpath routing for /mdma deployment

### DIFF
--- a/client-app/src/Components/Footer.tsx
+++ b/client-app/src/Components/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const Footer = () => {
     const footerStyle: React.CSSProperties = {
@@ -30,9 +31,10 @@ const Footer = () => {
                 </span>{' '}
                 &nbsp;|&nbsp; 2414 Menard Street, St. Louis, MO 63104
                 &nbsp;|&nbsp; (314) 664-0828
-                <a href="/contact" style={linkStyle}>
-                    Contact Page
-                </a>
+                <Link to="/contact" style={linkStyle}>
+                  
+		  Contact Page
+                </Link>
             </div>
         </footer>
     );

--- a/client-app/src/Components/LoginPage.tsx
+++ b/client-app/src/Components/LoginPage.tsx
@@ -167,9 +167,9 @@ const LoginPage: React.FC = () => {
                     data.role === 'TIER_TWO' ||
                     data.role === 'TIER_THREE'
                 ) {
-                    window.location.href = '/';
+                    window.location.href = (process.env.PUBLIC_URL || '') + '/';
                 } else if (data.role === 'DONOR') {
-                    window.location.href = '/donor-profile';
+                    window.location.href = (process.env.PUBLIC_URL || '') + '/donor-profile';
                 } else {
                     setErrorMessage(
                         'Unknown user role. Please contact support.',

--- a/client-app/src/Components/Navbar.tsx
+++ b/client-app/src/Components/Navbar.tsx
@@ -52,7 +52,7 @@ const Navbar: React.FC = () => {
 
         // Ensure UI updates by reloading the page or using event dispatch
         window.dispatchEvent(new Event('storage'));
-        window.location.href = '/';
+        window.location.href = (process.env.PUBLIC_URL || '') + '/';
     };
 
     return (

--- a/client-app/src/Components/Register.tsx
+++ b/client-app/src/Components/Register.tsx
@@ -216,7 +216,7 @@ const Register: React.FC = () => {
                 setPasswordStrength(null);
                 setShowGuidelines(false);
                 setTimeout(() => {
-                    window.location.href = '/About';
+                    window.location.href = (process.env.PUBLIC_URL || '') + '/About';
                 }, 2000);
             } else {
                 setErrorMessage(data.message || 'Registration failed');

--- a/client-app/src/index.js
+++ b/client-app/src/index.js
@@ -10,7 +10,7 @@ const root = createRoot(container);
 
 root.render(
     <React.StrictMode>
-        <BrowserRouter>
+        <BrowserRouter basename={process.env.PUBLIC_URL || "/"}>
             <App />
         </BrowserRouter>
     </React.StrictMode>,


### PR DESCRIPTION
Add basename to BrowserRouter so React Router respects PUBLIC_URL. Replace window.location.href with PUBLIC_URL-prefixed paths. Convert raw <a href> to <Link> in Footer for consistent routing.

Without this, navigating after login goes to /About instead of /mdma/About, which 404s at the ingress layer.
